### PR TITLE
[bugfix] userRepository

### DIFF
--- a/src/main/java/com/sparta/sbug/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/sbug/user/repository/UserRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     /**
@@ -30,4 +31,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     void disableInUseByEmail(@Param("email") String email);
 
     Optional<User> findByKakaoIdAndInUseIsTrue(Long kakaoId);
+
+    /**
+     * InUse 상태의 모든 유저를 반환
+     */
+    List<User> findByInUseTrue();
 }

--- a/src/main/java/com/sparta/sbug/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/sbug/user/service/UserServiceImpl.java
@@ -90,7 +90,7 @@ public class UserServiceImpl implements UserService {
     @Cacheable(cacheNames = CacheNames.ALLUSERS)
     @Transactional(readOnly = true)
     public List<UserResponseDto> getUsers() {
-        return userRepository.findAll().stream().map(this::getUserResponseDto).toList();
+        return userRepository.findByInUseTrue().stream().map(this::getUserResponseDto).toList();
     }
 
     @Override


### PR DESCRIPTION
added findByInUseTrue Method
UserService.getUsers() calls userRepository.findByInUseTrue()

회원탈퇴를 해도 탈퇴한 회원이
채팅 초대창에서 계속 보이는 문제가 있었습니다.

현재 userService.getUsers()는 user에 의해서만 호출됩니다.
InUse값이 True인 User들만 가져오도록 바꿨습니다.

만약 InUse의 True False 여부와 상관없이 모든 User를 조회하는
관리자용 method가 필요할 경우
따로 UserService에 정의해줄 필요가 있습니다.
(현재 AdminController에도 아직은 유저 전체조회 method가 없어서
일단은 놔뒀습니다.)